### PR TITLE
Was adding unchanged url(x) to the url map

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -109,7 +109,10 @@ function getUrlMap(css, resolvePaths, relativeBase) {
       continue;
     }
     var relativePath = path.relative(relativeBase, file).replace(/\\/g, '/');
-    urlMap[urlSyntax] = 'url("'+relativePath+'")';
+
+    var urlSyntaxRelative = 'url("'+relativePath+'")';
+    if (urlSyntax === urlSyntaxRelative) continue;
+    urlMap[urlSyntax] = urlSyntaxRelative;
   }
   return urlMap;
 }


### PR DESCRIPTION
If an css url(x) statement matched the the replacement, it was still being added to the url map. This caused an infinite replace loop as per the previous pull request I sent. (#6)

```
.test { background-image:url("/images/test.png") }
```
