### PR TITLE
Fix infinite loop due to double quotes uris

### DIFF
--- a/lib/cssjoin.js
+++ b/lib/cssjoin.js
@@ -79,6 +79,7 @@ CssJoin.prototype.resolveResources = function(css, resolvePaths){
   var urlMap = inutil.getUrlMap(css, resolvePaths, relativeBase)
 
   for(var pattern in urlMap) {
+    pattern = pattern.replace('"','');
     while (css.indexOf(pattern) !== -1) {
       css = css.replace(pattern, urlMap[pattern]);
     }


### PR DESCRIPTION
I had issues with double quotes uris, this example will be likely to produce an infinite loop in the parser :

``` css
body {
    background-image: uri("./img/background.png");
}
```

The fix is very simple, please tell me if it's convenient
